### PR TITLE
Fix in Babel_SingleTx.py to add the extra suffix in the result file name read by Brainsight.

### DIFF
--- a/BabelBrain/Babel_SingleTx/Babel_SingleTx.py
+++ b/BabelBrain/Babel_SingleTx/Babel_SingleTx.py
@@ -130,6 +130,7 @@ class SingleTx(QWidget):
         extrasuffix='Foc%03.1f_Diam%03.1f_' %(FocalLength,Diameter)
         self._FullSolName=self._MainApp._prefix_path+extrasuffix+'DataForSim.h5' 
         self._WaterSolName=self._MainApp._prefix_path+extrasuffix+'Water_DataForSim.h5'
+        self._MainApp._BrainsightInput=self._MainApp._prefix_path+extrasuffix+'FullElasticSolution.nii.gz'
 
         print('FullSolName',self._FullSolName)
         print('WaterSolName',self._WaterSolName)


### PR DESCRIPTION
I observed that when using the Single LIFU system Brainsight was looking for the result in the wrong location.

The issues is the extra suffix containing the values for the focal length in diameter settings.