### PR TITLE
Fix for BSonix LIFU where the Brainsight input file path was incorrect.

### DIFF
--- a/BabelBrain/Babel_SingleTx/Babel_BSonix.py
+++ b/BabelBrain/Babel_SingleTx/Babel_BSonix.py
@@ -100,6 +100,7 @@ class BSonix(SingleTx):
         self._FullSolName=self._MainApp._prefix_path+model+'_DataForSim.h5' 
         self._WaterSolName=self._MainApp._prefix_path+model+'_Water_DataForSim.h5' 
         extrasuffix=model+'_'
+        self._MainApp._BrainsightInput=self._MainApp._prefix_path+extrasuffix+'FullElasticSolution.nii.gz'
         print('FullSolName',self._FullSolName)
         print('WaterSolName',self._WaterSolName)
         bCalcFields=False


### PR DESCRIPTION
Today doing some tests realized that the BSonix LIFU is providing the wrong path (for Brainsight) for the result of the acoustic simulation.

This is very similar to PR #26 but at that time, IIRC, BSonix support was incomplete and I could not apply the same change.