### PR TITLE
fix environment_linux.yml: add cmake, relax typing-extensions pin

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -9,6 +9,7 @@ dependencies:
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2022.12.7=ha878542_0
   - certifi=2022.12.7=pyhd8ed1ab_0
+  - cmake
   - cudatoolkit=10.2.89=h713d32c_10
   - cudatoolkit-dev=11.7.0=h1de0b5d_6
   - cupy=12.0.0=py310h5a5d52f_0
@@ -99,7 +100,7 @@ dependencies:
       - superqt==0.4.1
       - tifffile==2023.3.21
       - trimesh==4.7.3
-      - typing-extensions==4.5.0
+      - typing-extensions>=4.10
       - uhi==0.3.3
       - urllib3==1.26.15
       - vtk==9.5.2


### PR DESCRIPTION
Creating the Linux conda environment fails with two separate errors. Both are fixed here.

### 1. typing-extensions version conflict

typing-extensions==4.5.0 is pinned, but two other pip dependencies require a newer version:
- pytools==2022.1.14 requires typing_extensions>=4.0
- pyvista==0.46.5 requires typing-extensions>=4.10

Fix: Relax the pin to >=4.10.

### 2. Missing cmake — babelviscofdtd fails to build

babelviscofdtd is installed from source via pip and requires cmake at build time. Without it declared as a conda dependency the build fails:

    cmake: symbol lookup error: cmake: undefined symbol: uv_fs_get_system_error
    Command ['cmake', '--version'] returned non-zero exit status 127
    ERROR: Failed building wheel for babelviscofdtd
    CondaEnvException: Pip failed

Fix: Add cmake to the conda dependencies so it is available before pip runs.
