### PR TITLE
Create a small chunk to run voxelize.py in 4GB CUDA Ram

### DIFF
--- a/BabelBrain/GPUFunctions/GPUBinaryClosing/BinaryClosing.py
+++ b/BabelBrain/GPUFunctions/GPUBinaryClosing/BinaryClosing.py
@@ -121,7 +121,7 @@ def erode_kernel(input, structure, output, offsets, border_value, center_is_true
 
     totalPoints = output.size
     logger.info(f"Total points: {totalPoints}")
-    step = get_step_size(sel_device,num_large_buffers=2,data_type=output.dtype,GPUBackend=GPUBackend)
+    step = get_step_size(sel_device,num_large_buffers=2,bytes_per_point=output.dtype.itemsize,GPUBackend=GPUBackend)
 
     for point in range(0,totalPoints,step):
 

--- a/BabelBrain/GPUFunctions/GPUMapping/MappingFilter.py
+++ b/BabelBrain/GPUFunctions/GPUMapping/MappingFilter.py
@@ -96,7 +96,7 @@ def MapFilter(HUMap,SelBone,UniqueHU,GPUBackend='OpenCL'):
     int_params[3] = HUMap.shape[2]
  
     totalPoints = output.size
-    step = get_step_size(sel_device,num_large_buffers=3,data_type=output.dtype,GPUBackend=GPUBackend)
+    step = get_step_size(sel_device,num_large_buffers=3,bytes_per_point=output.dtype.itemsize,GPUBackend=GPUBackend)
     logger.info(f"Total points: {totalPoints}")
     
     for point in range(0,totalPoints,step):

--- a/BabelBrain/GPUFunctions/GPUMedianFilter/MedianFilter.py
+++ b/BabelBrain/GPUFunctions/GPUMedianFilter/MedianFilter.py
@@ -96,7 +96,7 @@ def MedianFilter(data,size,GPUBackend='OpenCL'):
     output = np.zeros_like(data)
     totalPoints = output.size
     logger.info(f"Total points: {totalPoints}")
-    step = get_step_size(sel_device,num_large_buffers=2,data_type=data.dtype,GPUBackend=GPUBackend)
+    step = get_step_size(sel_device,num_large_buffers=2,bytes_per_point=data.dtype.itemsize,GPUBackend=GPUBackend)
 
     # Handle array in chunks
     for point in range(0,totalPoints,step):

--- a/BabelBrain/GPUFunctions/GPUResample/Resample.py
+++ b/BabelBrain/GPUFunctions/GPUResample/Resample.py
@@ -347,7 +347,7 @@ def ResampleFromTo(from_img, to_vox_map,order=3,mode="constant",cval=0.0,out_cla
     assert(np.isfortran(filtered)==False)
 
     totalPoints = output.size
-    step = get_step_size(sel_device,num_large_buffers=1,data_type=output.dtype,GPUBackend=GPUBackend)
+    step = get_step_size(sel_device,num_large_buffers=1,bytes_per_point=output.dtype.itemsize,GPUBackend=GPUBackend)
     logger.info(f"Total points: {totalPoints}")
     for point in range(0,totalPoints,step):
 

--- a/BabelBrain/GPUFunctions/GPUUtils.py
+++ b/BabelBrain/GPUFunctions/GPUUtils.py
@@ -6,6 +6,8 @@ import platform
 import sys
 
 _IS_MAC = platform.system() == 'Darwin'
+GIB = 1024**3
+MIB = GIB/1024
 
 def resource_path():  # needed for bundling
     """Get absolute path to resource, works for dev and for PyInstaller"""
@@ -19,28 +21,73 @@ def resource_path():  # needed for bundling
 
     return bundle_dir
 
+def get_default_step(gpu_device, GPUBackend):
+    import pyopencl as pocl
 
-def get_step_size(gpu_device,num_large_buffers,data_type,GPUBackend):
+    total_VRAM = 0
 
+    if GPUBackend == 'OpenCL':
+        total_VRAM = gpu_device.get_info(pocl.device_info.GLOBAL_MEM_SIZE)
+    else:
+        if GPUBackend == 'CUDA':
+            import cupy as cp
+            device_name = cp.cuda.runtime.getDeviceProperties(gpu_device.id)['name'].decode('UTF-8')
+        elif GPUBackend in ['Metal','MLX']:
+            device_name = gpu_device.deviceName
+
+        selected_device = None
+        for platform in pocl.get_platforms():
+            for device in platform.get_devices():
+                if device_name in device.name:
+                    selected_device = device
+
+        total_VRAM = selected_device.get_info(pocl.device_info.GLOBAL_MEM_SIZE)
+
+    if total_VRAM < 8 * GIB:
+        # This new value should work for even low-VRAM GPUs such as RTX A1000 4GB and prevents 
+        # OOM errors. However GPU kernels will run slower
+        default_step = 5000000
+    else:
+        default_step = 240000000
+    return default_step
+
+def get_step_size(gpu_device,num_large_buffers,bytes_per_point,GPUBackend):
+    
     # Set default step size value
-    step = 240000000
+    step = get_default_step(gpu_device,GPUBackend)
     
     # Find optimal step size based on GPU device limitations
     if GPUBackend == 'CUDA':
         import cupy as cp
 
-        # Get available memory
-        gpu_available_memory = cp.cuda.Device(gpu_device).mem_info[0]
-        logger.info(f"GPU available memory: {gpu_available_memory} bytes")
+        # Grab GPU memory information
+        with cp.cuda.Device(gpu_device):
+            cp.get_default_memory_pool().free_all_blocks()
+            free_memory, total_memory = cp.cuda.runtime.memGetInfo()
+            mempool = cp.get_default_memory_pool()
+        logger.info(f"GPU memory: {free_memory / GIB:.3f} GiB free / {total_memory / GIB:.3f} GiB total")
+        logger.info(f"CuPy pool used: {mempool.used_bytes() / GIB:.3f} GiB")
+        logger.info(f"CuPy pool total: {mempool.total_bytes() / GIB:.3f} GiB")
 
-        # Check for valid response
-        if gpu_available_memory == 0:
-            print(f"Queried GPU available memory returned 0, most likely a communication issue, will try using default step size ({step})")
+        # Communication error check
+        if free_memory == 0:
+            logger.warning(f"Queried GPU available memory returned 0, most likely a communication issue, will try using default step size ({step}).")
             return step
 
-        # Get GPU max buffer size
-        max_buffer_size = gpu_available_memory // num_large_buffers
-        logger.info(f"GPU max buffer size for {num_large_buffers} array(s): {max_buffer_size} bytes")
+        # Reserve memory for CUDA/CuPy/temporary allocations.
+        reserve_memory = 512 * MIB  # 512 MiB
+        logger.info(f"Reserved GPU memory: {reserve_memory / MIB:.0f} MiB")
+
+        # Calculate usuable memory
+        usable_memory = max(0,free_memory - reserve_memory,)
+        logger.info(f"Usable GPU memory: {usable_memory / GIB:.3f} GiB")
+
+        # Limited memory check
+        if usable_memory == 0:
+            logger.warning(f"Limited available memory, will try using default step size ({step})")
+            return step
+        
+        max_buffer_size = (usable_memory // num_large_buffers)
 
     elif GPUBackend == 'OpenCL':
         import pyopencl as pocl
@@ -72,11 +119,11 @@ def get_step_size(gpu_device,num_large_buffers,data_type,GPUBackend):
         return step
     
     # Determine largest safe buffer size
-    max_buffer_size = int(max_buffer_size * 0.8)  # Use 80% to be safe
-    logger.info(f"GPU max safe buffer size: {max_buffer_size} bytes")
+    max_safe_buffer_size = int(max_buffer_size * 0.8)  # Use 80% to be safe
+    logger.info(f"Max buffer size: {max_safe_buffer_size / GIB:.3f} GiB")
 
     # Determine appropriate step size
-    step = max_buffer_size//data_type.itemsize # Accounting for array dtype size
+    step = int(max_buffer_size // bytes_per_point)
     logger.info(f"Step size: {step}")
 
     return step

--- a/BabelBrain/GPUFunctions/GPUVoxelize/Voxelize.py
+++ b/BabelBrain/GPUFunctions/GPUVoxelize/Voxelize.py
@@ -267,37 +267,25 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
     totalGrid = gx * gy * gz
     logger.info(f"TotalGrid: {totalGrid}")
 
+    # Note the large buffer in this case is the Points array and will be 3 times the size of the totalGrid 
+    # since each point in the grid will have an i,j,k value
     step = get_step_size(
         sel_device,
-        num_large_buffers=2,
-        data_type=Points.dtype,
+        num_large_buffers=1,
+        bytes_per_point=Points.dtype.itemsize*3,
         GPUBackend=GPUBackend
     )
-
-    # PATCH for low-VRAM GPUs such as RTX A1000 4GB:
-    # The original step can create very large points_section arrays.
-    # Capping step makes voxelization slower but prevents CUDA/CuPy OOM.
-    MAX_GPU_POINTS_PER_CHUNK = 5000000
-
-    if GPUBackend == 'CUDA' and step > MAX_GPU_POINTS_PER_CHUNK:
-        print(
-            "Capping CUDA voxelization step for low-VRAM GPU:",
-            step,
-            "->",
-            MAX_GPU_POINTS_PER_CHUNK,
-        )
-        step = MAX_GPU_POINTS_PER_CHUNK
-
+    points_section_size = min(step,totalPoints)
     globalcount = np.zeros(2, np.uint32)
     int_params = np.zeros(4, np.uint32)
     prev_start_ind = 0
 
     for point in range(0, totalGrid, step):
-        ntotal = min((totalGrid - point), step)
-        logger.info(f"\nWorking on points {point} to {point + ntotal} out of {totalGrid}")
+        num_points = min((totalGrid - point), step)
+        logger.info(f"\nWorking on points {point} to {point + num_points} out of {totalGrid}")
 
-        # Allocate only what this chunk needs.
-        points_section = np.zeros((min(ntotal, totalPoints), 3), np.float32)
+        # Grab sections of data
+        points_section = np.zeros((points_section_size,3), np.float32)
 
         # Since we run into issues sending numbers larger than 32 bits due to buffer size restrictions,
         # we check the size here, send info to kernel, and create number there as workaround.
@@ -305,7 +293,7 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
         base_32 = current_position // (2**32)
         current_position = current_position - (base_32 * (2**32))
 
-        int_params[0] = ntotal
+        int_params[0] = num_points
         int_params[1] = current_position
         int_params[2] = base_32
         int_params[3] = prev_start_ind
@@ -319,7 +307,7 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
 
                 # Define block and grid sizes
                 block_size = (64, 1, 1)
-                grid_size = (int(ntotal // block_size[0] + 1), 1, 1)
+                grid_size = (int(num_points // block_size[0] + 1), 1, 1)
 
                 # Deploy kernel
                 prgcl.get_function("ExtractPoints")(
@@ -340,11 +328,11 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
                 points_section = points_section_gpu.get()
                 globalcount = globalcount_gpu.get()
 
-                # Explicitly release CUDA/CuPy temporary arrays before next chunk.
+                # Delete array references but keep the memory allocated in CuPy's pool for 
+                # next chunk to save time.
                 del points_section_gpu
                 del globalcount_gpu
                 del int_params_gpu
-                clp.get_default_memory_pool().free_all_blocks()
 
         elif GPUBackend == 'OpenCL':
             # Move input data from host to device memory
@@ -355,7 +343,7 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
             # Deploy kernel
             clExtractPoints(
                 queue,
-                [ntotal],
+                [num_points],
                 None,
                 vtable_gpu,
                 globalcount_gpu,
@@ -382,7 +370,7 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
             # Deploy kernel
             ctx.init_command_buffer()
             handle = prg.function('ExtractPoints')(
-                ntotal,
+                num_points,
                 vtable_gpu,
                 globalcount_gpu,
                 int_params_gpu,
@@ -407,7 +395,7 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
 
             globalcount_gpu = prg_ExtractPoints(
                 inputs=[vtable_gpu, int_params_gpu, points_section_gpu],
-                grid=[ntotal, 1, 1],
+                grid=[num_points, 1, 1],
                 threadgroup=[1024, 1, 1],
                 output_shapes=[[globalcount.size]],
                 output_dtypes=[ctx.uint32],
@@ -431,10 +419,13 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
             raise ValueError("Error running voxelization for specified parameters, suggest lowering PPW")
 
         prev_start_ind = int(globalcount[0])
-
-    print('prev_start_ind', prev_start_ind)
+        print('prev_start_ind', prev_start_ind)
     print('globalcount', globalcount)
- 
+    if int(globalcount[0]) != int(totalPoints):
+        raise RuntimeError(
+            f"Point extraction incomplete: "
+            f"expected {totalPoints}, extracted {globalcount[0]}"
+        )
     Points[:,0]+=0.5
     Points[:,1]+=0.5
     Points[:,2]+=0.5

--- a/BabelBrain/GPUFunctions/GPUVoxelize/Voxelize.py
+++ b/BabelBrain/GPUFunctions/GPUVoxelize/Voxelize.py
@@ -264,32 +264,53 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
     Points=np.zeros((totalPoints,3),np.float32)
 
     # Extract points
-    totalGrid=gx*gy*gz
+    totalGrid = gx * gy * gz
     logger.info(f"TotalGrid: {totalGrid}")
-    step = get_step_size(sel_device,num_large_buffers=2,data_type=Points.dtype,GPUBackend=GPUBackend)
-    points_section_size = min(step,totalPoints)
-    globalcount=np.zeros(2,np.uint32)
-    int_params = np.zeros(4,np.uint32)
+
+    step = get_step_size(
+        sel_device,
+        num_large_buffers=2,
+        data_type=Points.dtype,
+        GPUBackend=GPUBackend
+    )
+
+    # PATCH for low-VRAM GPUs such as RTX A1000 4GB:
+    # The original step can create very large points_section arrays.
+    # Capping step makes voxelization slower but prevents CUDA/CuPy OOM.
+    MAX_GPU_POINTS_PER_CHUNK = 5000000
+
+    if GPUBackend == 'CUDA' and step > MAX_GPU_POINTS_PER_CHUNK:
+        print(
+            "Capping CUDA voxelization step for low-VRAM GPU:",
+            step,
+            "->",
+            MAX_GPU_POINTS_PER_CHUNK,
+        )
+        step = MAX_GPU_POINTS_PER_CHUNK
+
+    globalcount = np.zeros(2, np.uint32)
+    int_params = np.zeros(4, np.uint32)
     prev_start_ind = 0
-    for point in range(0,totalGrid,step):
-        ntotal = min((totalGrid-point),step)
-        logger.info(f"\nWorking on points {point} to {point+ntotal} out of {totalGrid}")
 
-        # Grab sections of data
-        points_section = np.zeros((points_section_size,3),np.float32)
+    for point in range(0, totalGrid, step):
+        ntotal = min((totalGrid - point), step)
+        logger.info(f"\nWorking on points {point} to {point + ntotal} out of {totalGrid}")
 
-        # Since we run into issues sending numbers larger than 32 bits due to buffer size restrictions, 
-        # we check the size here, send info to kernel, and create number there as workaround
+        # Allocate only what this chunk needs.
+        points_section = np.zeros((min(ntotal, totalPoints), 3), np.float32)
+
+        # Since we run into issues sending numbers larger than 32 bits due to buffer size restrictions,
+        # we check the size here, send info to kernel, and create number there as workaround.
         current_position = point
         base_32 = current_position // (2**32)
         current_position = current_position - (base_32 * (2**32))
 
-        int_params[0]=ntotal
-        int_params[1]=current_position
-        int_params[2]=base_32
-        int_params[3]=prev_start_ind
+        int_params[0] = ntotal
+        int_params[1] = current_position
+        int_params[2] = base_32
+        int_params[3] = prev_start_ind
 
-        if GPUBackend=='CUDA':
+        if GPUBackend == 'CUDA':
             with ctx:
                 # Move input data from host to device memory
                 points_section_gpu = clp.asarray(points_section)
@@ -297,96 +318,122 @@ def Voxelize(inputMesh,targetResolution=1333/500e3/6*0.75*1e3,GPUBackend='OpenCL
                 int_params_gpu = clp.asarray(int_params)
 
                 # Define block and grid sizes
-                block_size = (64,1,1)
-                grid_size=(int(ntotal//Block[0]+1),1,1)
-                
+                block_size = (64, 1, 1)
+                grid_size = (int(ntotal // block_size[0] + 1), 1, 1)
+
                 # Deploy kernel
-                prgcl.get_function("ExtractPoints")(grid_size,block_size,
-                                                    (vtable_gpu,
-                                                    globalcount_gpu,
-                                                    points_section_gpu,
-                                                    int_params_gpu,
-                                                    np.uint32(gx),
-                                                    np.uint32(gy),
-                                                    np.uint32(gz)))
+                prgcl.get_function("ExtractPoints")(
+                    grid_size,
+                    block_size,
+                    (
+                        vtable_gpu,
+                        globalcount_gpu,
+                        points_section_gpu,
+                        int_params_gpu,
+                        np.uint32(gx),
+                        np.uint32(gy),
+                        np.uint32(gz),
+                    )
+                )
 
                 # Move kernel output data back to host memory
-                points_section=points_section_gpu.get()
-                globalcount=globalcount_gpu.get()
+                points_section = points_section_gpu.get()
+                globalcount = globalcount_gpu.get()
 
-        elif GPUBackend=='OpenCL':
+                # Explicitly release CUDA/CuPy temporary arrays before next chunk.
+                del points_section_gpu
+                del globalcount_gpu
+                del int_params_gpu
+                clp.get_default_memory_pool().free_all_blocks()
+
+        elif GPUBackend == 'OpenCL':
             # Move input data from host to device memory
-            points_section_gpu=clp.Buffer(ctx, mf.WRITE_ONLY, points_section.nbytes)
-            globalcount_gpu=clp.Buffer(ctx, mf.READ_WRITE| mf.COPY_HOST_PTR, hostbuf=globalcount )
+            points_section_gpu = clp.Buffer(ctx, mf.WRITE_ONLY, points_section.nbytes)
+            globalcount_gpu = clp.Buffer(ctx, mf.READ_WRITE | mf.COPY_HOST_PTR, hostbuf=globalcount)
             int_params_gpu = clp.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=int_params)
-        
+
             # Deploy kernel
-            clExtractPoints(queue,[ntotal],None,vtable_gpu,
-                                                globalcount_gpu,
-                                                points_section_gpu,
-                                                int_params_gpu,
-                                                np.uint32(gx),
-                                                np.uint32(gy),
-                                                np.uint32(gz))
+            clExtractPoints(
+                queue,
+                [ntotal],
+                None,
+                vtable_gpu,
+                globalcount_gpu,
+                points_section_gpu,
+                int_params_gpu,
+                np.uint32(gx),
+                np.uint32(gy),
+                np.uint32(gz)
+            )
             queue.finish()
 
             # Move kernel output data back to host memory
-            clp.enqueue_copy(queue, points_section,points_section_gpu)
+            clp.enqueue_copy(queue, points_section, points_section_gpu)
             queue.finish()
-            clp.enqueue_copy(queue, globalcount,globalcount_gpu)
+            clp.enqueue_copy(queue, globalcount, globalcount_gpu)
             queue.finish()
 
-        elif GPUBackend=='Metal' :
+        elif GPUBackend == 'Metal':
             # Move input data from host to device memory
-            points_section_gpu=ctx.buffer(points_section.nbytes)
-            globalcount_gpu=ctx.buffer(globalcount)
+            points_section_gpu = ctx.buffer(points_section.nbytes)
+            globalcount_gpu = ctx.buffer(globalcount)
             int_params_gpu = ctx.buffer(int_params)
 
             # Deploy kernel
             ctx.init_command_buffer()
-            handle = prg.function('ExtractPoints')(ntotal,vtable_gpu,globalcount_gpu,int_params_gpu,points_section_gpu)
+            handle = prg.function('ExtractPoints')(
+                ntotal,
+                vtable_gpu,
+                globalcount_gpu,
+                int_params_gpu,
+                points_section_gpu
+            )
             ctx.commit_command_buffer()
             ctx.wait_command_buffer()
             del handle
+
             if 'arm64' not in platform.platform():
-                ctx.sync_buffers((points_section_gpu,globalcount_gpu))
+                ctx.sync_buffers((points_section_gpu, globalcount_gpu))
 
             # Move kernel output data back to host memory
-            points_section=np.frombuffer(points_section_gpu,dtype=np.float32).reshape(points_section.shape)
-            globalcount=np.frombuffer(globalcount_gpu,dtype=np.uint32)
+            points_section = np.frombuffer(points_section_gpu, dtype=np.float32).reshape(points_section.shape)
+            globalcount = np.frombuffer(globalcount_gpu, dtype=np.uint32)
             logger.info(f"globalcount: {globalcount}")
-        elif GPUBackend=='MLX' :
+
+        elif GPUBackend == 'MLX':
             # Move input data from host to device memory
-            points_section_gpu=ctx.zeros(points_section.size)
-            # globalcount_gpu=ctx.array(globalcount)
+            points_section_gpu = ctx.zeros(points_section.size)
             int_params_gpu = ctx.array(int_params)
 
-            globalcount_gpu=prg_ExtractPoints(inputs=[vtable_gpu,int_params_gpu,points_section_gpu],
-                       grid=[ntotal,1,1],
-                       threadgroup=[1024,1,1],
-                       output_shapes=[[globalcount.size]], 
-                       output_dtypes=[ctx.uint32],
-                       use_optimal_threadgroups=True,
-                       init_value=0,
-                        )[0]
+            globalcount_gpu = prg_ExtractPoints(
+                inputs=[vtable_gpu, int_params_gpu, points_section_gpu],
+                grid=[ntotal, 1, 1],
+                threadgroup=[1024, 1, 1],
+                output_shapes=[[globalcount.size]],
+                output_dtypes=[ctx.uint32],
+                use_optimal_threadgroups=True,
+                init_value=0,
+            )[0]
 
             ctx.eval(globalcount_gpu)
-            
+
             # Move kernel output data back to host memory
-            points_section=np.array(points_section_gpu).reshape(points_section.shape)
-            globalcount+=np.array(globalcount_gpu)
+            points_section = np.array(points_section_gpu).reshape(points_section.shape)
+            globalcount += np.array(globalcount_gpu)
 
             logger.info(f"globalcount: {globalcount}")
 
         try:
-            Points[prev_start_ind:int(globalcount[0]),:]=points_section[:int(globalcount[0])-prev_start_ind,:]
+            n_new_points = int(globalcount[0]) - prev_start_ind
+            Points[prev_start_ind:int(globalcount[0]), :] = points_section[:n_new_points, :]
         except Exception as e:
             print(e)
             raise ValueError("Error running voxelization for specified parameters, suggest lowering PPW")
-        prev_start_ind=int(globalcount[0])
-        print('prev_start_ind', prev_start_ind)
 
-    print('globalcount',globalcount)
+        prev_start_ind = int(globalcount[0])
+
+    print('prev_start_ind', prev_start_ind)
+    print('globalcount', globalcount)
  
     Points[:,0]+=0.5
     Points[:,1]+=0.5


### PR DESCRIPTION
On our computer, the crash occurs when BabelBrain voxelizes the SimNIBS STL skin/skull mesh, because we have only 4 GB of GPU memory available with CUDA on Ubuntu.

We updated the code to make BabelBrain process the voxelization in smaller GPU chunks. This is a software workaround for the memory limitation. The error occurs because BabelBrain tries to send a very large array to the GPU at once:

points_section_gpu = clp.asarray(points_section)

We also ran the same participant on a system with 8 GB of GPU memory without modifying Voxelize.py, and the simulation results were the same as those obtained with the patched version on the 4 GB GPU.