### PR TITLE
REMOPD: Brainsight feasible trajectory workflow and Y steering map

### DIFF
--- a/BabelBrain/BabelBrain.py
+++ b/BabelBrain/BabelBrain.py
@@ -1085,15 +1085,22 @@ class BabelBrain(QWidget):
                 self._TrajectoryNumber+=1
                 self.ExecuteTrajectory()
 
-    def ReadTrajectory(self,bGetID=False):
-         if self.Config['TrajectoryType']=='brainsight':
-             return ReadTrajectoryBrainsight(self.Config['Mat4Trajectory'],bGetID=bGetID)
-         elif self.Config['TrajectoryType']=='slicer':
-             return read_converted_itk_affine_transform(self.Config['Mat4Trajectory'],bGetID=bGetID)
-         elif self.Config['TrajectoryType']=='localite':
-             return LocaliteTargeting.from_file(self.Config['Mat4Trajectory']).ReturnBabelBrainTrajectories(bGetID=bGetID)
-         else:
-             raise ValueError("trajectory type not supported yet: "+self.Config['TrajectoryType'])
+    def ReadTrajectory(self,bGetID=False,sel_fname=''):
+        if len(sel_fname)>0:
+            if not os.path.isfile(sel_fname):
+                raise ValueError(f'sel_fname should point to a valid file: {sel_fname}')
+            input_fname = sel_fname
+        else:
+            input_fname = self.Config['Mat4Trajectory']
+             
+        if self.Config['TrajectoryType']=='brainsight':
+            return ReadTrajectoryBrainsight(input_fname,bGetID=bGetID)
+        elif self.Config['TrajectoryType']=='slicer':
+            return read_converted_itk_affine_transform(input_fname,bGetID=bGetID)
+        elif self.Config['TrajectoryType']=='localite':
+            return LocaliteTargeting.from_file(input_fname).ReturnBabelBrainTrajectories(bGetID=bGetID)
+        else:
+            raise ValueError("trajectory type not supported yet: "+self.Config['TrajectoryType'])
          
 
     #this will modify the coordinates of the trajectory

--- a/BabelBrain/Babel_H317/H317Form.py
+++ b/BabelBrain/Babel_H317/H317Form.py
@@ -70,7 +70,7 @@ class H317Form(TxPanelBase):
         lay.addSpacing(6)
 
         self._build_mech_and_actions(
-            lay, xy_mech=(-10.0, 10.0), z_mechanic=(-90.0, 90.0),
+            lay, xy_mech=(-40.0, 40.0), z_mechanic=(-90.0, 90.0),
             tissue_warning=None)
         # feasible-traj: Sam's SOP — park the array on a Brainsight
         # feasible pose (mechanical X/Y) and ballpark-steer back to intended.

--- a/BabelBrain/Babel_H317/H317Form.py
+++ b/BabelBrain/Babel_H317/H317Form.py
@@ -12,6 +12,7 @@ from GUIComponents.TxPanelBase import (
     make_dspin,
     make_combo,
     make_label,
+    make_button,
     form_row,
 )
 from PySide6.QtWidgets import QCheckBox
@@ -71,4 +72,15 @@ class H317Form(TxPanelBase):
         self._build_mech_and_actions(
             lay, xy_mech=(-10.0, 10.0), z_mechanic=(-90.0, 90.0),
             tissue_warning=None)
+        # feasible-traj: Sam's SOP — park the array on a Brainsight
+        # feasible pose (mechanical X/Y) and ballpark-steer back to intended.
+        # Shown when TrajectoryType is Brainsight (wired in Babel_REMOPD).
+        self.ApplyFeasibleTraj = make_button(
+            "ApplyFeasibleTraj", "Apply feasible trajectory",
+            bold=True, min_height=40)
+        # Sit right under Calculate Mechanical Adjustments so the three action
+        # buttons stay grouped and the FLHM readout keeps the last row.
+        lay.insertWidget(lay.indexOf(self.CalculateMechAdj) + 1,
+                         self.ApplyFeasibleTraj)
+   
         return frame

--- a/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
+++ b/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
@@ -105,8 +105,9 @@ class REMOPD(BabelBasePhaseArray):
         self.Widget.LabelTissueRemoved.setVisible(False)
         self.Widget.CalculateMechAdj.clicked.connect(self.CalculateMechAdj)
         self.Widget.CalculateMechAdj.setEnabled(False)
-        # Sam: Y-flip and this action only when BabelBrain is called from Brainsight.
-        b_brainsight = bool(self._MainApp.Config.get('bInUseWithBrainsight'))
+        # Y-flip and Apply feasible when TrajectoryType is Brainsight (not only
+        # when launched via -bInUseWithBrainsight).
+        b_brainsight = self._MainApp.Config.get('TrajectoryType') == 'brainsight'
         self.Widget.ApplyFeasibleTraj.setVisible(b_brainsight)
         if b_brainsight:
             self.Widget.ApplyFeasibleTraj.clicked.connect(self.ApplyFeasibleTrajectory)
@@ -146,7 +147,7 @@ class REMOPD(BabelBasePhaseArray):
         electronic focus stays on intended. DeviceFrameSteering is an involution,
         so the same map fills the GUI when Brainsight Y is flipped in the solver.
         '''
-        if not bool(self._MainApp.Config.get('bInUseWithBrainsight')):
+        if self._MainApp.Config.get('TrajectoryType') != 'brainsight':
             return
         start = ''
         mat4 = self._MainApp.Config.get('Mat4Trajectory') or ''
@@ -342,8 +343,8 @@ class RunAcousticSim(QObject):
         kargs['ZSteering']=ZSteering
         kargs['RotationZ']=RotationZ
         kargs['TxSet']=TxSet
-        # GUI Y stays as typed; the solver flips Y only in Brainsight mode.
-        kargs['bFlipSteeringY']=bool(self._mainApp.Config.get('bInUseWithBrainsight'))
+        # GUI Y stays as typed; flip Y in the solver for Brainsight trajectories.
+        kargs['bFlipSteeringY']=self._mainApp.Config.get('TrajectoryType') == 'brainsight'
         kargs['Frequencies']=Frequencies
         kargs['zLengthBeyonFocalPointWhenNarrow']=self._mainApp.AcSim.Widget.MaxDepthSpinBox.value()/1e3
         kargs['bDoRefocusing']=bRefocus

--- a/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
+++ b/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
@@ -51,8 +51,6 @@ class REMOPD(BabelBasePhaseArray):
     @property
     def FlipSteeringY(self):
         yflip = self._MainApp.Config.get('TrajectoryType') == 'brainsight'
-        if yflip:
-            print('Flipping Y Steering for brainsight operation for REMOPD')
         return yflip
 
     def _CreateForm(self):
@@ -248,6 +246,8 @@ class RunAcousticSim(QObject):
         kargs['TxSet']=TxSet
         # GUI Y stays as typed; flip Y in the solver for Brainsight trajectories.
         kargs['bFlipSteeringY']= self._mainApp.AcSim.FlipSteeringY
+        if kargs['bFlipSteeringY']:
+            print('Flipping Y Steering for brainsight operation for REMOPD')
         kargs['Frequencies']=Frequencies
         kargs['zLengthBeyonFocalPointWhenNarrow']=self._mainApp.AcSim.Widget.MaxDepthSpinBox.value()/1e3
         kargs['bDoRefocusing']=bRefocus

--- a/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
+++ b/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import sys
 
-from PySide6.QtWidgets import QApplication, QMessageBox, QVBoxLayout
+from PySide6.QtWidgets import QApplication, QMessageBox, QVBoxLayout, QFileDialog
 from PySide6.QtCore import QFile,Slot,QObject,Signal,QThread,Qt
 from PySide6.QtUiTools import QUiLoader
 
@@ -21,9 +21,13 @@ import yaml
 from BabelViscoFDTD.H5pySimple import ReadFromH5py
 from GUIComponents.ScrollBars import ScrollBars as WidgetScrollBars
 
+import nibabel
+
 from CalculateFieldProcess import CalculateFieldProcess
 
 from _BabelBasePhasedArray import BabelBasePhaseArray
+from ConvMatTransform import ReadTrajectoryBrainsight
+from TranscranialModeling.BabelIntegrationREMOPD import DeviceFrameSteering
 
 _IS_MAC = platform.system() == 'Darwin'
 def resource_path():  # needed for bundling
@@ -37,6 +41,38 @@ def resource_path():  # needed for bundling
         bundle_dir = Path(__file__).parent
 
     return bundle_dir
+
+def _brainsight_origin_ras_mm(path):
+    '''Origin (Loc X/Y/Z) of a Brainsight trajectory export, in NIfTI RAS mm.'''
+    R = ReadTrajectoryBrainsight(path)
+    if getattr(R, 'ndim', 2) == 3:
+        R = R[:, :, 0]
+    return np.asarray(R[:3, 3], dtype=float)
+
+def mechanical_xy_from_feasible_ras_mm(mask_path, ras_mm):
+    '''Raw domain X/Y (mm) from a feasible RAS point to the intended target.
+
+    Same math as Sam's CalcRayXYDistance.py: intended = label 5 in the
+    Step 1 *BabelViscoInput.nii.gz (the trajectory BabelBrain was launched
+    with). Keeps that intended point at the center of Step 2/3.
+    '''
+    if not mask_path or 'BabelViscoInput.nii.gz' not in os.path.basename(mask_path):
+        raise ValueError('Step 1 mask (*BabelViscoInput.nii.gz) is not available.')
+    if not os.path.isfile(mask_path):
+        raise ValueError('Run Step 1 first so the simulation mask exists.')
+
+    # Sam's CalcRayXYDistance.py, verbatim (label 5 = intended target).
+    ras = np.array([float(ras_mm[0]), float(ras_mm[1]), float(ras_mm[2]), 1], dtype=float).reshape((4, 1))
+    inb = nibabel.load(mask_path)
+    zoom = inb.header.get_zooms()
+    data = inb.get_fdata().astype(int)
+    TargetIJK = np.array(np.where(data == 5)).flatten()
+    if TargetIJK.size < 3:
+        raise ValueError('Intended target (label 5) was not found in the Step 1 mask.')
+    inv_affine = np.linalg.inv(inb.affine)
+    AffIJK = np.round(np.dot(inv_affine, ras)).flatten()[:3]
+    DiffIJK = AffIJK - TargetIJK
+    return float(DiffIJK[0] * zoom[0]), float(DiffIJK[1] * zoom[1])
 
 class REMOPD(BabelBasePhaseArray): 
     def __init__(self,parent=None,MainApp=None):
@@ -69,6 +105,11 @@ class REMOPD(BabelBasePhaseArray):
         self.Widget.LabelTissueRemoved.setVisible(False)
         self.Widget.CalculateMechAdj.clicked.connect(self.CalculateMechAdj)
         self.Widget.CalculateMechAdj.setEnabled(False)
+        # Sam: Y-flip and this action only when BabelBrain is called from Brainsight.
+        b_brainsight = bool(self._MainApp.Config.get('bInUseWithBrainsight'))
+        self.Widget.ApplyFeasibleTraj.setVisible(b_brainsight)
+        if b_brainsight:
+            self.Widget.ApplyFeasibleTraj.clicked.connect(self.ApplyFeasibleTrajectory)
         self.up_load_ui()
         
     @Slot()
@@ -95,6 +136,72 @@ class REMOPD(BabelBasePhaseArray):
         DistanceFromSkin = self.CalculateDistanceFromSkin()
         self.Widget.ZSteeringSpinBox.setValue(np.round(DistanceFromSkin,1))
 
+    @Slot()
+    def ApplyFeasibleTrajectory(self):
+        '''Park the array on a Brainsight feasible pose; steer back to intended.
+
+        remopd/feasible-traj: intended trajectory (already loaded) stays label 5.
+        The user picks the feasible Brainsight .txt (no retyped RAS). Mechanical
+        X/Y slide the array to that pose; steering is the opposite offset so the
+        electronic focus stays on intended. DeviceFrameSteering is an involution,
+        so the same map fills the GUI when Brainsight Y is flipped in the solver.
+        '''
+        if not bool(self._MainApp.Config.get('bInUseWithBrainsight')):
+            return
+        start = ''
+        mat4 = self._MainApp.Config.get('Mat4Trajectory') or ''
+        if mat4 and os.path.isfile(mat4):
+            start = os.path.dirname(mat4)
+        elif self._MainApp.Config.get('OutputFilesPath'):
+            start = self._MainApp.Config['OutputFilesPath']
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            'Select Brainsight feasible trajectory',
+            start,
+            'Brainsight trajectory (*.txt);;All files (*)')
+        if not path:
+            return
+        try:
+            masks = getattr(self._MainApp, '_outnameMask', None)
+            idx = getattr(self, '_TrajectoryNumber', 0)
+            if not masks:
+                raise ValueError('Run Step 1 first so the simulation mask exists.')
+            mask_path = masks[idx]
+            ras = _brainsight_origin_ras_mm(path)
+            mech_x, mech_y = mechanical_xy_from_feasible_ras_mm(mask_path, ras)
+            # Domain steer that keeps the focus on label 5 after the array slides.
+            gui_x, gui_y = DeviceFrameSteering(-mech_x, -mech_y, flip_y=True)
+        except Exception as e:
+            QMessageBox.critical(self, 'Apply feasible trajectory', str(e))
+            return
+
+        self.Widget.XMechanicSpinBox.setValue(np.round(mech_x, 1))
+        self.Widget.YMechanicSpinBox.setValue(np.round(mech_y, 1))
+        self.Widget.XSteeringSpinBox.setValue(np.round(gui_x, 1))
+        self.Widget.YSteeringSpinBox.setValue(np.round(gui_y, 1))
+
+        xmin = self.Widget.XSteeringSpinBox.minimum()
+        xmax = self.Widget.XSteeringSpinBox.maximum()
+        ymin = self.Widget.YSteeringSpinBox.minimum()
+        ymax = self.Widget.YSteeringSpinBox.maximum()
+        warn = []
+        if not (xmin <= gui_x <= xmax) or not (ymin <= gui_y <= ymax):
+            warn.append('Steering is outside the allowed range and was clamped.')
+        mxmin = self.Widget.XMechanicSpinBox.minimum()
+        mxmax = self.Widget.XMechanicSpinBox.maximum()
+        mymin = self.Widget.YMechanicSpinBox.minimum()
+        mymax = self.Widget.YMechanicSpinBox.maximum()
+        if not (mxmin <= mech_x <= mxmax) or not (mymin <= mech_y <= mymax):
+            warn.append('Mechanical X/Y are outside the allowed range and were clamped.')
+        extra = ('\n\n' + ' '.join(warn)) if warn else ''
+        QMessageBox.information(
+            self,
+            'Apply feasible trajectory',
+            'Mechanical X, Y (mm): %0.1f, %0.1f\n'
+            'Steering X, Y (mm): %0.1f, %0.1f\n\n'
+            'Mechanical slides the array to the feasible pose. '
+            'Steering is the opposite offset so the focus stays on the intended target.'
+            '%s' % (mech_x, mech_y, gui_x, gui_y, extra))
 
     @Slot()
     def _ResolveSimulationFilenames(self):
@@ -234,8 +341,9 @@ class RunAcousticSim(QObject):
         kargs['YSteering']=YSteering
         kargs['ZSteering']=ZSteering
         kargs['RotationZ']=RotationZ
-        kargs['RotationZ']=RotationZ
         kargs['TxSet']=TxSet
+        # GUI Y stays as typed; the solver flips Y only in Brainsight mode.
+        kargs['bFlipSteeringY']=bool(self._mainApp.Config.get('bInUseWithBrainsight'))
         kargs['Frequencies']=Frequencies
         kargs['zLengthBeyonFocalPointWhenNarrow']=self._mainApp.AcSim.Widget.MaxDepthSpinBox.value()/1e3
         kargs['bDoRefocusing']=bRefocus

--- a/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
+++ b/BabelBrain/Babel_REMOPD/Babel_REMOPD.py
@@ -26,8 +26,7 @@ import nibabel
 from CalculateFieldProcess import CalculateFieldProcess
 
 from _BabelBasePhasedArray import BabelBasePhaseArray
-from ConvMatTransform import ReadTrajectoryBrainsight
-from TranscranialModeling.BabelIntegrationREMOPD import DeviceFrameSteering
+from ConvMatTransform import ReadTrajectoryBrainsight, read_converted_itk_affine_transform
 
 _IS_MAC = platform.system() == 'Darwin'
 def resource_path():  # needed for bundling
@@ -42,44 +41,20 @@ def resource_path():  # needed for bundling
 
     return bundle_dir
 
-def _brainsight_origin_ras_mm(path):
-    '''Origin (Loc X/Y/Z) of a Brainsight trajectory export, in NIfTI RAS mm.'''
-    R = ReadTrajectoryBrainsight(path)
-    if getattr(R, 'ndim', 2) == 3:
-        R = R[:, :, 0]
-    return np.asarray(R[:3, 3], dtype=float)
-
-def mechanical_xy_from_feasible_ras_mm(mask_path, ras_mm):
-    '''Raw domain X/Y (mm) from a feasible RAS point to the intended target.
-
-    Same math as Sam's CalcRayXYDistance.py: intended = label 5 in the
-    Step 1 *BabelViscoInput.nii.gz (the trajectory BabelBrain was launched
-    with). Keeps that intended point at the center of Step 2/3.
-    '''
-    if not mask_path or 'BabelViscoInput.nii.gz' not in os.path.basename(mask_path):
-        raise ValueError('Step 1 mask (*BabelViscoInput.nii.gz) is not available.')
-    if not os.path.isfile(mask_path):
-        raise ValueError('Run Step 1 first so the simulation mask exists.')
-
-    # Sam's CalcRayXYDistance.py, verbatim (label 5 = intended target).
-    ras = np.array([float(ras_mm[0]), float(ras_mm[1]), float(ras_mm[2]), 1], dtype=float).reshape((4, 1))
-    inb = nibabel.load(mask_path)
-    zoom = inb.header.get_zooms()
-    data = inb.get_fdata().astype(int)
-    TargetIJK = np.array(np.where(data == 5)).flatten()
-    if TargetIJK.size < 3:
-        raise ValueError('Intended target (label 5) was not found in the Step 1 mask.')
-    inv_affine = np.linalg.inv(inb.affine)
-    AffIJK = np.round(np.dot(inv_affine, ras)).flatten()[:3]
-    DiffIJK = AffIJK - TargetIJK
-    return float(DiffIJK[0] * zoom[0]), float(DiffIJK[1] * zoom[1])
-
 class REMOPD(BabelBasePhaseArray): 
     def __init__(self,parent=None,MainApp=None):
         super().__init__(parent=parent,MainApp=MainApp,formtype=os.path.join(resource_path(), "."))
 
     # Inherits BabelBasePhaseArray.load_ui (-> _setupTrajectoryTabs); only the
     # form and its wiring differ.
+
+    @property
+    def FlipSteeringY(self):
+        yflip = self._MainApp.Config.get('TrajectoryType') == 'brainsight'
+        if yflip:
+            print('Flipping Y Steering for brainsight operation for REMOPD')
+        return yflip
+
     def _CreateForm(self):
         from Babel_REMOPD.REMOPDForm import REMOPDForm
         return REMOPDForm(self)
@@ -105,12 +80,7 @@ class REMOPD(BabelBasePhaseArray):
         self.Widget.LabelTissueRemoved.setVisible(False)
         self.Widget.CalculateMechAdj.clicked.connect(self.CalculateMechAdj)
         self.Widget.CalculateMechAdj.setEnabled(False)
-        # Y-flip and Apply feasible when TrajectoryType is Brainsight (not only
-        # when launched via -bInUseWithBrainsight).
-        b_brainsight = self._MainApp.Config.get('TrajectoryType') == 'brainsight'
-        self.Widget.ApplyFeasibleTraj.setVisible(b_brainsight)
-        if b_brainsight:
-            self.Widget.ApplyFeasibleTraj.clicked.connect(self.ApplyFeasibleTrajectory)
+        self.Widget.ApplyFeasibleTraj.clicked.connect(self.ApplyFeasibleTrajectory)
         self.up_load_ui()
         
     @Slot()
@@ -136,73 +106,6 @@ class REMOPD(BabelBasePhaseArray):
         self._SyncActiveTrajectoryFromMainApp()
         DistanceFromSkin = self.CalculateDistanceFromSkin()
         self.Widget.ZSteeringSpinBox.setValue(np.round(DistanceFromSkin,1))
-
-    @Slot()
-    def ApplyFeasibleTrajectory(self):
-        '''Park the array on a Brainsight feasible pose; steer back to intended.
-
-        remopd/feasible-traj: intended trajectory (already loaded) stays label 5.
-        The user picks the feasible Brainsight .txt (no retyped RAS). Mechanical
-        X/Y slide the array to that pose; steering is the opposite offset so the
-        electronic focus stays on intended. DeviceFrameSteering is an involution,
-        so the same map fills the GUI when Brainsight Y is flipped in the solver.
-        '''
-        if self._MainApp.Config.get('TrajectoryType') != 'brainsight':
-            return
-        start = ''
-        mat4 = self._MainApp.Config.get('Mat4Trajectory') or ''
-        if mat4 and os.path.isfile(mat4):
-            start = os.path.dirname(mat4)
-        elif self._MainApp.Config.get('OutputFilesPath'):
-            start = self._MainApp.Config['OutputFilesPath']
-        path, _ = QFileDialog.getOpenFileName(
-            self,
-            'Select Brainsight feasible trajectory',
-            start,
-            'Brainsight trajectory (*.txt);;All files (*)')
-        if not path:
-            return
-        try:
-            masks = getattr(self._MainApp, '_outnameMask', None)
-            idx = getattr(self, '_TrajectoryNumber', 0)
-            if not masks:
-                raise ValueError('Run Step 1 first so the simulation mask exists.')
-            mask_path = masks[idx]
-            ras = _brainsight_origin_ras_mm(path)
-            mech_x, mech_y = mechanical_xy_from_feasible_ras_mm(mask_path, ras)
-            # Domain steer that keeps the focus on label 5 after the array slides.
-            gui_x, gui_y = DeviceFrameSteering(-mech_x, -mech_y, flip_y=True)
-        except Exception as e:
-            QMessageBox.critical(self, 'Apply feasible trajectory', str(e))
-            return
-
-        self.Widget.XMechanicSpinBox.setValue(np.round(mech_x, 1))
-        self.Widget.YMechanicSpinBox.setValue(np.round(mech_y, 1))
-        self.Widget.XSteeringSpinBox.setValue(np.round(gui_x, 1))
-        self.Widget.YSteeringSpinBox.setValue(np.round(gui_y, 1))
-
-        xmin = self.Widget.XSteeringSpinBox.minimum()
-        xmax = self.Widget.XSteeringSpinBox.maximum()
-        ymin = self.Widget.YSteeringSpinBox.minimum()
-        ymax = self.Widget.YSteeringSpinBox.maximum()
-        warn = []
-        if not (xmin <= gui_x <= xmax) or not (ymin <= gui_y <= ymax):
-            warn.append('Steering is outside the allowed range and was clamped.')
-        mxmin = self.Widget.XMechanicSpinBox.minimum()
-        mxmax = self.Widget.XMechanicSpinBox.maximum()
-        mymin = self.Widget.YMechanicSpinBox.minimum()
-        mymax = self.Widget.YMechanicSpinBox.maximum()
-        if not (mxmin <= mech_x <= mxmax) or not (mymin <= mech_y <= mymax):
-            warn.append('Mechanical X/Y are outside the allowed range and were clamped.')
-        extra = ('\n\n' + ' '.join(warn)) if warn else ''
-        QMessageBox.information(
-            self,
-            'Apply feasible trajectory',
-            'Mechanical X, Y (mm): %0.1f, %0.1f\n'
-            'Steering X, Y (mm): %0.1f, %0.1f\n\n'
-            'Mechanical slides the array to the feasible pose. '
-            'Steering is the opposite offset so the focus stays on the intended target.'
-            '%s' % (mech_x, mech_y, gui_x, gui_y, extra))
 
     @Slot()
     def _ResolveSimulationFilenames(self):
@@ -344,7 +247,7 @@ class RunAcousticSim(QObject):
         kargs['RotationZ']=RotationZ
         kargs['TxSet']=TxSet
         # GUI Y stays as typed; flip Y in the solver for Brainsight trajectories.
-        kargs['bFlipSteeringY']=self._mainApp.Config.get('TrajectoryType') == 'brainsight'
+        kargs['bFlipSteeringY']= self._mainApp.AcSim.FlipSteeringY
         kargs['Frequencies']=Frequencies
         kargs['zLengthBeyonFocalPointWhenNarrow']=self._mainApp.AcSim.Widget.MaxDepthSpinBox.value()/1e3
         kargs['bDoRefocusing']=bRefocus

--- a/BabelBrain/Babel_REMOPD/REMOPDForm.py
+++ b/BabelBrain/Babel_REMOPD/REMOPDForm.py
@@ -69,7 +69,7 @@ class REMOPDForm(TxPanelBase):
         self._build_mech_and_actions(
             lay, xy_mech=(-40.0, 40.0), skin_distance=(-90.0, 90.0),
             tissue_warning="Tissue layers\nwill be removed!")
-        # remopd/feasible-traj: Sam's SOP — park the array on a Brainsight
+        # feasible-traj: Sam's SOP — park the array on a Brainsight
         # feasible pose (mechanical X/Y) and ballpark-steer back to intended.
         # Shown when TrajectoryType is Brainsight (wired in Babel_REMOPD).
         self.ApplyFeasibleTraj = make_button(

--- a/BabelBrain/Babel_REMOPD/REMOPDForm.py
+++ b/BabelBrain/Babel_REMOPD/REMOPDForm.py
@@ -9,6 +9,7 @@ from GUIComponents.TxPanelBase import (
     make_dspin,
     make_combo,
     make_label,
+    make_button,
     form_row,
 )
 from PySide6.QtWidgets import QCheckBox
@@ -63,4 +64,13 @@ class REMOPDForm(TxPanelBase):
         self._build_mech_and_actions(
             lay, xy_mech=(-40.0, 40.0), skin_distance=(-90.0, 90.0),
             tissue_warning="Tissue layers\nwill be removed!")
+        # remopd/feasible-traj: Sam's SOP — park the array on a Brainsight
+        # feasible pose (mechanical X/Y) and ballpark-steer back to intended.
+        # Shown only when launched from Brainsight (wired in Babel_REMOPD).
+        self.ApplyFeasibleTraj = make_button(
+            "ApplyFeasibleTraj", "Apply feasible trajectory...",
+            bold=True, min_height=40)
+        # _build_mech_and_actions ends with a stretch; keep this with the
+        # Calculate Fields / Mechanical Adjustments buttons.
+        lay.insertWidget(lay.count() - 1, self.ApplyFeasibleTraj)
         return frame

--- a/BabelBrain/Babel_REMOPD/REMOPDForm.py
+++ b/BabelBrain/Babel_REMOPD/REMOPDForm.py
@@ -66,7 +66,7 @@ class REMOPDForm(TxPanelBase):
             tissue_warning="Tissue layers\nwill be removed!")
         # remopd/feasible-traj: Sam's SOP — park the array on a Brainsight
         # feasible pose (mechanical X/Y) and ballpark-steer back to intended.
-        # Shown only when launched from Brainsight (wired in Babel_REMOPD).
+        # Shown when TrajectoryType is Brainsight (wired in Babel_REMOPD).
         self.ApplyFeasibleTraj = make_button(
             "ApplyFeasibleTraj", "Apply feasible trajectory",
             bold=True, min_height=40)

--- a/BabelBrain/Babel_REMOPD/REMOPDForm.py
+++ b/BabelBrain/Babel_REMOPD/REMOPDForm.py
@@ -68,7 +68,7 @@ class REMOPDForm(TxPanelBase):
         # feasible pose (mechanical X/Y) and ballpark-steer back to intended.
         # Shown only when launched from Brainsight (wired in Babel_REMOPD).
         self.ApplyFeasibleTraj = make_button(
-            "ApplyFeasibleTraj", "Apply feasible trajectory...",
+            "ApplyFeasibleTraj", "Apply feasible trajectory",
             bold=True, min_height=40)
         # _build_mech_and_actions ends with a stretch; keep this with the
         # Calculate Fields / Mechanical Adjustments buttons.

--- a/BabelBrain/Babel_REMOPD/REMOPDForm.py
+++ b/BabelBrain/Babel_REMOPD/REMOPDForm.py
@@ -18,6 +18,11 @@ from PySide6.QtWidgets import QCheckBox
 class REMOPDForm(TxPanelBase):
     def _build_left_panel(self):
         frame, lay = self._make_left_frame()
+        # Densest of the Step-2 columns (6 geometry rows + 3 action buttons):
+        # shave a pixel off the row spacing so the extra ApplyFeasibleTraj
+        # button below fits without making this panel drive the window's
+        # minimum height.
+        lay.setSpacing(3)
 
         # Tx element set
         self.MultifocusLabel = make_label("Tx Elements Set",
@@ -49,7 +54,7 @@ class REMOPDForm(TxPanelBase):
             decimals=1, step=5.0)
         lay.addLayout(form_row("Z Rotation (degrees)", self.ZRotationSpinBox))
 
-        lay.addSpacing(6)
+        lay.addSpacing(2)
 
         # Device → target display
         self.DistanceSkinLabel = make_label(
@@ -59,7 +64,7 @@ class REMOPDForm(TxPanelBase):
             make_label("Distance device\nto target (mm) :"),
             self.DistanceSkinLabel))
 
-        lay.addSpacing(6)
+        lay.addSpacing(2)
 
         self._build_mech_and_actions(
             lay, xy_mech=(-40.0, 40.0), skin_distance=(-90.0, 90.0),
@@ -70,7 +75,8 @@ class REMOPDForm(TxPanelBase):
         self.ApplyFeasibleTraj = make_button(
             "ApplyFeasibleTraj", "Apply feasible trajectory",
             bold=True, min_height=40)
-        # _build_mech_and_actions ends with a stretch; keep this with the
-        # Calculate Fields / Mechanical Adjustments buttons.
-        lay.insertWidget(lay.count() - 1, self.ApplyFeasibleTraj)
+        # Sit right under Calculate Mechanical Adjustments so the three action
+        # buttons stay grouped and the FLHM readout keeps the last row.
+        lay.insertWidget(lay.indexOf(self.CalculateMechAdj) + 1,
+                         self.ApplyFeasibleTraj)
         return frame

--- a/BabelBrain/Babel_Thermal/Babel_Thermal.py
+++ b/BabelBrain/Babel_Thermal/Babel_Thermal.py
@@ -1054,6 +1054,10 @@ class Babel_Thermal(QWidget):
                 delattr(self,'_figIntThermalFields')
                 # self._layout.deleteLater()
                 
+            xSign=1
+            if vp['view']=='YZ':
+                if self._MainApp.AcSim.FlipSteeringY:
+                    xSign=-1
 
             if hasattr(self,'_figIntThermalFields'):
                 if WhatDisplay==0:
@@ -1077,15 +1081,15 @@ class Babel_Thermal(QWidget):
                             if 'AirMask' in DataThermal:
                                 del self._airmask1
                                 del self._airmask2
-                            
-                            self._contour1=self._static_ax1.contour(self._XX,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
-                            self._contour2=self._static_ax2.contour(self._XX,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
+
+                            self._contour1=self._static_ax1.contour(self._XX*xSign,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
+                            self._contour2=self._static_ax2.contour(self._XX*xSign,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
 
                             if 'AirMask' in DataThermal:
                                 AirMap=self._SlicePlane(DataThermal['AirMask'],SelY,axis).T
                                 AirMap=np.ma.masked_where(AirMap==0 , AirMap)
-                                self._airmask1 = self._static_ax1.contourf(self._XX,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
-                                self._airmask2 = self._static_ax2.contourf(self._XX,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
+                                self._airmask1 = self._static_ax1.contourf(self._XX*xSign,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
+                                self._airmask2 = self._static_ax2.contourf(self._XX*xSign,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
 
                     while len(self._ListMarkers)>0:
                         obj= self._ListMarkers.pop()
@@ -1122,13 +1126,13 @@ class Babel_Thermal(QWidget):
                     self._static_ax1=static_ax1
                     self._static_ax2=static_ax2
 
-                    _extent=[vp['hvec'].min(),vp['hvec'].max(),vp['vvec'].max(),vp['vvec'].min()]
+                    _extent=[xSign*vp['hvec'].min(),xSign*vp['hvec'].max(),vp['vvec'].max(),vp['vvec'].min()]
                     self._IntensityIm=static_ax1.imshow(IntensityMap,extent=_extent,
                             cmap=plt.cm.jet)
                     static_ax1.set_title('Isppa (W/cm$^2$)')
                     plt.colorbar(self._IntensityIm,ax=static_ax1)
                     if not self._MainApp.Config['bForceHomogenousMedium']:
-                        self._contour1=static_ax1.contour(self._XX,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims,colors ='y',linestyles = ':')
+                        self._contour1=static_ax1.contour(self._XX*xSign,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims,colors ='y',linestyles = ':')
 
                     static_ax1.set_xlabel(vp['hlabel'])
                     static_ax1.set_ylabel(vp['vlabel'])
@@ -1141,13 +1145,13 @@ class Babel_Thermal(QWidget):
 
                     plt.colorbar(self._ThermalIm,ax=static_ax2)
                     if not self._MainApp.Config['bForceHomogenousMedium']:
-                        self._contour2=static_ax2.contour(self._XX,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
+                        self._contour2=static_ax2.contour(self._XX*xSign,self._ZZ,self._SlicePlane(AcSimMask,SelY,axis).T,crlims, colors ='y',linestyles = ':')
 
                     if 'AirMask' in DataThermal:
                         AirMap=self._SlicePlane(DataThermal['AirMask'],SelY,axis).T
                         AirMap=np.ma.masked_where(AirMap==0 , AirMap)
-                        self._airmask1 = static_ax1.contourf(self._XX,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
-                        self._airmask2 = static_ax2.contourf(self._XX,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
+                        self._airmask1 = static_ax1.contourf(self._XX*xSign,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
+                        self._airmask2 = static_ax2.contourf(self._XX*xSign,self._ZZ,AirMap,[0,1],cmap=plt.cm.gray_r)
 
                     self._figIntThermalFields.set_facecolor(self._MainApp._BackgroundColorFigures)
                 else:

--- a/BabelBrain/_BabelBasePhasedArray.py
+++ b/BabelBrain/_BabelBasePhasedArray.py
@@ -136,10 +136,6 @@ class BabelBasePhaseArray(BabelBaseTx):
             R = R[:, :, 0]
         return np.asarray(R[:3, 3], dtype=float)
 
-    @property
-    def FlipSteeringY(self):
-        return False #default for most devices
-
     def DeviceFrameSteering(self,XSteering, YSteering):
         '''Map GUI electronic steering into simulation-domain axes.
 

--- a/BabelBrain/_BabelBasePhasedArray.py
+++ b/BabelBrain/_BabelBasePhasedArray.py
@@ -52,7 +52,6 @@ class BabelBasePhaseArray(BabelBaseTx):
         self.DefaultConfig()
         self.load_ui(formtype)
 
-
     def load_ui(self,formtype):
         # the concrete form class is passed in via `formtype` (a class, or a
         # legacy path resolved by suffix); stash it for _CreateForm and build the
@@ -105,8 +104,123 @@ class BabelBasePhaseArray(BabelBaseTx):
             self.Widget.ZMechaniclabel.setVisible(False)
         self.Widget.CalculateMechAdj.clicked.connect(self.CalculateMechAdj)
         self.Widget.CalculateMechAdj.setEnabled(False)
+        self.Widget.ApplyFeasibleTraj.clicked.connect(self.ApplyFeasibleTrajectory)
         self.up_load_ui()
-        
+
+
+    def  mechanical_xy_from_feasible_ras_mm(self, ras_mm):
+        '''Raw domain X/Y (mm) from a feasible RAS point to the intended target.
+
+        Same math as Sam's CalcRayXYDistance.py: intended = label 5 in the
+        Step 1 *BabelViscoInput.nii.gz (the trajectory BabelBrain was launched
+        with). Keeps that intended point at the center of Step 2/3.
+        '''
+
+        # Sam's CalcRayXYDistance.py, verbatim (label 5 = intended target).
+        ras = np.array([float(ras_mm[0]), float(ras_mm[1]), float(ras_mm[2]), 1], dtype=float).reshape((4, 1))
+        inb = self._MainApp._MaskNib[self._TrajectoryNumber]
+        zoom = inb.header.get_zooms()
+        data = self._MainApp.FinalMaskRaw[self._TrajectoryNumber].astype(int)
+        TargetIJK = np.array(np.where(data == 5)).flatten()
+        if TargetIJK.size < 3:
+            raise ValueError('Intended target (label 5) was not found in the Step 1 mask.')
+        inv_affine = np.linalg.inv(inb.affine)
+        AffIJK = np.round(np.dot(inv_affine, ras)).flatten()[:3]
+        DiffIJK = AffIJK - TargetIJK
+        return float(DiffIJK[0] * zoom[0]), float(DiffIJK[1] * zoom[1])
+
+    def _origin_feasible_ras_mm(self,path):
+        '''Origin (Loc X/Y/Z) of a Brainsight trajectory export, in NIfTI RAS mm.'''
+        R = self._MainApp.ReadTrajectory(bGetID=False,sel_fname=path)
+        if getattr(R, 'ndim', 2) == 3:
+            R = R[:, :, 0]
+        return np.asarray(R[:3, 3], dtype=float)
+
+    @property
+    def FlipSteeringY(self):
+        return False #default for most devices
+
+    def DeviceFrameSteering(self,XSteering, YSteering):
+        '''Map GUI electronic steering into simulation-domain axes.
+
+        Changed on remopd/feasible-traj (TW / Brainsight): hydrophone checks showed
+        GUI +Y is opposite the device/domain +Y. Sam asked that this swap apply
+        only when BabelBrain is launched from Brainsight, so Slicer and Localite
+        keep the identity map until a shared convention exists. Mechanical X/Y
+        are already domain coordinates and are not mapped here.
+        '''
+        if self.FlipSteeringY:
+            return XSteering, -YSteering
+        return XSteering, YSteering
+
+    @Slot()
+    def ApplyFeasibleTrajectory(self):
+        '''Park the array on a Brainsight feasible pose; steer back to intended.
+
+        remopd/feasible-traj: intended trajectory (already loaded) stays label 5.
+        The user picks the feasible Brainsight .txt (no retyped RAS). Mechanical
+        X/Y slide the array to that pose; steering is the opposite offset so the
+        electronic focus stays on intended. DeviceFrameSteering is an involution,
+        so the same map fills the GUI when Brainsight Y is flipped in the solver.
+        '''
+        start = ''
+        mat4 = self._MainApp.Config.get('Mat4Trajectory') or ''
+        if mat4 and os.path.isfile(mat4):
+            start = os.path.dirname(mat4)
+        elif self._MainApp.Config.get('OutputFilesPath'):
+            start = self._MainApp.Config['OutputFilesPath']
+        if self._MainApp.Config['TrajectoryType']=='localite':
+            fileext = 'trajectory (*.xml *.XML)'
+        else:
+            fileext = 'trajectory (*.txt)'
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            'Select feasible trajectory',
+            start,
+            fileext)
+        if not path:
+            return
+        try:
+            masks = getattr(self._MainApp, '_outnameMask', None)
+            idx = getattr(self, '_TrajectoryNumber', 0)
+            if not masks:
+                raise ValueError('Run Step 1 first so the simulation mask exists.')
+            mask_path = masks[idx]
+            ras = self._origin_feasible_ras_mm(path)
+            mech_x, mech_y = self.mechanical_xy_from_feasible_ras_mm(ras)
+            # Domain steer that keeps the focus on label 5 after the array slides.
+            gui_x, gui_y = self.DeviceFrameSteering(-mech_x, -mech_y)
+        except Exception as e:
+            QMessageBox.critical(self, 'Apply feasible trajectory', str(e))
+            return
+
+        self.Widget.XMechanicSpinBox.setValue(np.round(mech_x, 1))
+        self.Widget.YMechanicSpinBox.setValue(np.round(mech_y, 1))
+        self.Widget.XSteeringSpinBox.setValue(np.round(gui_x, 1))
+        self.Widget.YSteeringSpinBox.setValue(np.round(gui_y, 1))
+
+        xmin = self.Widget.XSteeringSpinBox.minimum()
+        xmax = self.Widget.XSteeringSpinBox.maximum()
+        ymin = self.Widget.YSteeringSpinBox.minimum()
+        ymax = self.Widget.YSteeringSpinBox.maximum()
+        warn = []
+        if not (xmin <= gui_x <= xmax) or not (ymin <= gui_y <= ymax):
+            warn.append('Steering is outside the allowed range and was clamped.')
+        mxmin = self.Widget.XMechanicSpinBox.minimum()
+        mxmax = self.Widget.XMechanicSpinBox.maximum()
+        mymin = self.Widget.YMechanicSpinBox.minimum()
+        mymax = self.Widget.YMechanicSpinBox.maximum()
+        if not (mxmin <= mech_x <= mxmax) or not (mymin <= mech_y <= mymax):
+            warn.append('Mechanical X/Y are outside the allowed range and were clamped.')
+        extra = ('\n\n' + ' '.join(warn)) if warn else ''
+        QMessageBox.information(
+            self,
+            'Apply feasible trajectory',
+            'Mechanical X, Y (mm): %0.1f, %0.1f\n'
+            'Steering X, Y (mm): %0.1f, %0.1f\n\n'
+            'Mechanical slides the array to the feasible pose. '
+            'Steering is the opposite offset so the focus stays on the intended target.'
+            '%s' % (mech_x, mech_y, gui_x, gui_y, extra))    
        
     @Slot()
     def ZSteeringUpdate(self,value):

--- a/BabelBrain/_BabelBaseTx.py
+++ b/BabelBrain/_BabelBaseTx.py
@@ -137,6 +137,11 @@ class BabelBaseTx(QWidget):
         self._txTabs.setCurrentIndex(0)
         self._txTabs.currentChanged.connect(self._OnTrajectoryTabChanged)
 
+    @property
+    def FlipSteeringY(self):
+        # This property is used in Phased arrays where we need to swap Y axis
+        return False #default for most devices
+
     @Slot(int)
     def _OnTrajectoryTabChanged(self, idx):
         if not hasattr(self, '_Widgets') or idx < 0 or idx >= len(self._Widgets):
@@ -517,13 +522,21 @@ class BabelBaseTx(QWidget):
                 AirMap = np.ma.masked_where(AirMap == 0, AirMap)
                 panel['airmask1'] = ax1.contourf(XX, ZZX, AirMap, [0, 1], cmap=plt.cm.gray_r)
 
-        panel['imContourf2'] = ax2.contourf(YY, ZZY, Field[SelX, :, :].T, np.arange(2, 22, 2) / 20, cmap=plt.cm.jet)
+        if self.FlipSteeringY:
+            ySign=-1
+        else:
+            ySign=1
+
+        panel['imContourf2'] = ax2.contourf(YY*ySign, ZZY, Field[SelX, :, :].T, np.arange(2, 22, 2) / 20, cmap=plt.cm.jet)
         if not homog:
-            panel['contour2'] = ax2.contour(YY, ZZY, Skull['MaterialMap'][SelX, :, :].T, [0, 1, 2], colors='k', linestyles=':')
+            panel['contour2'] = ax2.contour(YY*ySign, ZZY, Skull['MaterialMap'][SelX, :, :].T, [0, 1, 2], colors='k', linestyles=':')
             if 'AirMask' in Skull:
                 AirMap = Skull['AirMask'][SelX, :, :].T
                 AirMap = np.ma.masked_where(AirMap == 0, AirMap)
-                panel['airmask2'] = ax2.contourf(YY, ZZY, AirMap, [0, 1], cmap=plt.cm.gray_r)
+                panel['airmask2'] = ax2.contourf(YY*ySign, ZZY, AirMap, [0, 1], cmap=plt.cm.gray_r)
+        if self.FlipSteeringY:
+            ax2.xaxis.set_inverted(True) 
+            
 
         # Colourbars and the y-axis flip are set once, with the first contourf.
         if not panel.get('cbDone'):

--- a/TranscranialModeling/BabelIntegrationCONCAVE_PHASEDARRAY.py
+++ b/TranscranialModeling/BabelIntegrationCONCAVE_PHASEDARRAY.py
@@ -158,12 +158,12 @@ class BabelFTD_Simulations(BabelFTD_Simulations_BASE):
         LocSpot=np.array(np.where(self._SkullMask.get_fdata(dtype=np.float32)==5.0)).flatten()
         
         for nt,st in enumerate(['VertDisplay','elemcenter']):
-            TxVert=self._SIM_SETTINGS._TxREMOPD[st].T.copy()
+            TxVert=self._SIM_SETTINGS._TxOrig[st].T.copy()
             TxVert/=self._SIM_SETTINGS.SpatialStep
             TxVert=np.vstack([TxVert,np.ones((1,TxVert.shape[1]))])
             TxVert[2,:]=-TxVert[2,:]
-            TxVert[0,:]+=LocSpot[0]
-            TxVert[1,:]+=LocSpot[1]
+            TxVert[0,:]+=LocSpot[0]+(self._TxMechanicalAdjustmentX/self._SIM_SETTINGS.SpatialStep)
+            TxVert[1,:]+=LocSpot[1]+(self._TxMechanicalAdjustmentY/self._SIM_SETTINGS.SpatialStep)
             TxVert[2,:]+=LocSpot[2]+self._SIM_SETTINGS._OrigFocalLength/self._SIM_SETTINGS.SpatialStep - self._SIM_SETTINGS._TxMechanicalAdjustmentZ/self._SIM_SETTINGS.SpatialStep
 
             TxVert=np.dot(affine,TxVert)

--- a/TranscranialModeling/BabelIntegrationREMOPD.py
+++ b/TranscranialModeling/BabelIntegrationREMOPD.py
@@ -234,9 +234,9 @@ class BabelFTD_Simulations(BabelFTD_Simulations_BASE):
             TxVert=np.vstack([TxVert,np.ones((1,TxVert.shape[1]))])
 
             TxVert[2,:]=-TxVert[2,:]
-            TxVert[0,:]+=LocSpot[0]+int(np.round(self._TxMechanicalAdjustmentX/self._SIM_SETTINGS.SpatialStep))
-            TxVert[1,:]+=LocSpot[1]+int(np.round(self._TxMechanicalAdjustmentY/self._SIM_SETTINGS.SpatialStep))
-            TxVert[2,:]+=LocSpot[2]+int(np.round((self._ZSteering-self._TxMechanicalAdjustmentZ)/self._SIM_SETTINGS.SpatialStep))
+            TxVert[0,:]+=LocSpot[0]+(self._TxMechanicalAdjustmentX/self._SIM_SETTINGS.SpatialStep)
+            TxVert[1,:]+=LocSpot[1]+(self._TxMechanicalAdjustmentY/self._SIM_SETTINGS.SpatialStep)
+            TxVert[2,:]+=LocSpot[2]+(self._ZSteering-self._TxMechanicalAdjustmentZ)/self._SIM_SETTINGS.SpatialStep
 
             TxVert=np.dot(affine,TxVert)
 

--- a/TranscranialModeling/BabelIntegrationREMOPD.py
+++ b/TranscranialModeling/BabelIntegrationREMOPD.py
@@ -38,6 +38,19 @@ def computeREMOPDGeometry():
     TxPos=loadmat(os.path.join(os.path.dirname(os.path.realpath(__file__)),'REMOPD_ElementPosition.mat'))['REMOPD_ElementPosition']
     return TxPos
 
+def DeviceFrameSteering(XSteering, YSteering, flip_y=False):
+    '''Map GUI electronic steering into REMOPD simulation-domain axes.
+
+    Changed on remopd/feasible-traj (TW / Brainsight): hydrophone checks showed
+    GUI +Y is opposite the device/domain +Y. Sam asked that this swap apply
+    only when BabelBrain is launched from Brainsight, so Slicer and Localite
+    keep the identity map until a shared convention exists. Mechanical X/Y
+    are already domain coordinates and are not mapped here.
+    '''
+    if flip_y:
+        return XSteering, -YSteering
+    return XSteering, YSteering
+
 def GenerateSingleElem(FREQ=300e3,PPW=12.0):
     #60.08 PPW produces close to integer steps for both pitch and kerf
     
@@ -157,6 +170,7 @@ class RUN_SIM(RUN_SIM_BASE):
                                     ZSteering=self._ZSteering,
                                     RotationZ=self._RotationZ,
                                     TxSet=self._TxSet,
+                                    bFlipSteeringY=self._bFlipSteeringY,
                                     **kargs)
     def RunCases(self,
                     XSteering=0.0,
@@ -164,12 +178,15 @@ class RUN_SIM(RUN_SIM_BASE):
                     ZSteering=60.0e-3,
                     RotationZ=0.0,
                     TxSet='Total', #Total selects all the 256 elements, Sector1 the central 128 elements, and Sector2 the external 128
+                    bFlipSteeringY=False,
                     **kargs):
         self._RotationZ=RotationZ
         self._XSteering=XSteering
         self._YSteering=YSteering
         self._ZSteering=ZSteering
         self._TxSet=TxSet
+        # Popped here so BASE CreateSimObject does not see an unknown kwarg.
+        self._bFlipSteeringY=bFlipSteeringY
         
         return super().RunCases(**kargs)
         
@@ -183,6 +200,7 @@ class BabelFTD_Simulations(BabelFTD_Simulations_BASE):
                  ZSteering=0.0,
                  RotationZ=0.0,
                  TxSet='Total', #Total selects all the 256 elements, Sector1 the central 128 elements, and Sector2 the external 128
+                 bFlipSteeringY=False,
                  **kargs):
         
         self._XSteering=XSteering
@@ -190,6 +208,7 @@ class BabelFTD_Simulations(BabelFTD_Simulations_BASE):
         self._ZSteering=ZSteering
         self._RotationZ=RotationZ
         self._TxSet=TxSet
+        self._bFlipSteeringY=bFlipSteeringY
         super().__init__(**kargs)
 
     def CreateSimConditions(self,**kargs):
@@ -198,6 +217,7 @@ class BabelFTD_Simulations(BabelFTD_Simulations_BASE):
                                     ZSteering=self._ZSteering,
                                     RotationZ=self._RotationZ,
                                     TxSet=self._TxSet,
+                                    bFlipSteeringY=self._bFlipSteeringY,
                                     FocalLength=0.0,
                                     Aperture=APERTURE, # m, aperture of the Tx, used tof calculated cross section area entering the domain
                                     **kargs)
@@ -266,6 +286,7 @@ class SimulationConditions(SimulationConditionsBASE):
                       ZSteering=0.0,
                       RotationZ=0.0,#rotation of Tx over Z axis
                       TxSet='Total', #Total selects all the 256 elements, Sector1 the central 128 elements, and Sector2 the external 128
+                      bFlipSteeringY=False,
                       **kargs):
         super().__init__(Aperture=Aperture,FocalLength=FocalLength,
                          ZTxCorrecton=-ZDistance, #this will put the required water space in the simulation domain
@@ -275,6 +296,7 @@ class SimulationConditions(SimulationConditionsBASE):
         self._ZSteering=ZSteering
         self._RotationZ=RotationZ
         self._TxSet = TxSet
+        self._bFlipSteeringY = bFlipSteeringY
         
     def CalculateRayleighFieldsForward(self,deviceName='6800'):
         print("Precalculating Rayleigh-based field as input for FDTD...")
@@ -328,11 +350,15 @@ class SimulationConditions(SimulationConditionsBASE):
             u0=np.zeros((1),np.complex64)
             u0[0]=1+0j
             center=np.zeros((1,3),np.float32)
-            center[0,0]=self._XDim[self._FocalSpotLocation[0]]+self._TxMechanicalAdjustmentX+self._XSteering
-            center[0,1]=self._YDim[self._FocalSpotLocation[1]]+self._TxMechanicalAdjustmentY+self._YSteering
+            # GUI Y is stored unchanged in the H5; flip only the focus used
+            # for phasing, and only when launched from Brainsight.
+            steerX, steerY = DeviceFrameSteering(
+                self._XSteering, self._YSteering, flip_y=self._bFlipSteeringY)
+            center[0,0]=self._XDim[self._FocalSpotLocation[0]]+self._TxMechanicalAdjustmentX+steerX
+            center[0,1]=self._YDim[self._FocalSpotLocation[1]]+self._TxMechanicalAdjustmentY+steerY
             center[0,2]=self._ZDim[self._ZSourceLocation]+self._ZSteering+zCorrec
 
-            print('center',center,np.mean(self._TxREMOPD['elemcenter'][:,2]))
+            print('center',center,'device-frame XY',(steerX, steerY),np.mean(self._TxREMOPD['elemcenter'][:,2]))
             
             u2back=ForwardSimple(cwvnb_extlay,center,ds.astype(np.float32),u0,self._TxREMOPD['elemcenter'].astype(np.float32),deviceMetal=deviceName)
             u0=np.zeros((self._TxREMOPD['center'].shape[0],1),np.complex64)


### PR DESCRIPTION
Summary:
- Adds a Brainsight **Apply feasible trajectory** action for REMOPD: intended target stays mask label 5; user picks a feasible Brainsight `.txt`; mechanical X/Y are filled from `CalcRayXYDistance` math and steering is set to the opposite domain offset so the focus stays on intended.
- Maps REMOPD electronic steering Y to device/domain axes only when `TrajectoryType == 'brainsight'`.
- GUI Y is stored unchanged in H5; the flip is applied only when building the Rayleigh focus for phasing. Mechanical X/Y are not Y-flipped.

Scope:
- `BabelBrain/Babel_REMOPD/Babel_REMOPD.py`
- `BabelBrain/Babel_REMOPD/REMOPDForm.py`
- `TranscranialModeling/BabelIntegrationREMOPD.py`

No changes to spec files, other transducers, steering-in-filenames, or virtual/actual RAS UI.